### PR TITLE
Updated base url for properly loading it on https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: "Aanjhan Ranganathan"
 description: ""
 
-url: "http://aanjhan.com"
+url: "https://aanjhan.com"
 destination: _site
 paginate: 10
 


### PR DESCRIPTION
Assets won't be loaded by the browser if they're on http url; therefore updating base url to https.
